### PR TITLE
Minor documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ You can manually configure every configuration by using a
 
 ```Python
 
-import pywebcopy
+from pywebcopy import config
 
 url = 'http://example-site.com/index.html'
 download_loc = 'path/to/downloads/'

--- a/README.md
+++ b/README.md
@@ -338,13 +338,13 @@ pywebcopy.config.setup_config(url, download_loc)
 
 # done!
 
->>> pywebcopy.config.config['url']
+>>> pywebcopy.config['url']
 'http://example-site.com/index.html'
 
->>> pywebcopy.config.config['mirrors_dir']
+>>> pywebcopy.config['mirrors_dir']
 'path/to/downloads'
 
->>> pywebcopy.config.config['project_name']
+>>> pywebcopy.config['project_name']
 'example-site.com'
 
 


### PR DESCRIPTION
using `import pywebcopy` , then `pywebcopy.config.config` throws this error: 
"AttributeError: 'ConfigHandler' object has no attribute 'config'"

but using `from pywebcopy import config` then calling `pywebcopy.config` works fine.