### PR TITLE
Fix for handling href tel: element in parse_url() urls.py

### DIFF
--- a/pywebcopy/urls.py
+++ b/pywebcopy/urls.py
@@ -195,6 +195,10 @@ def parse_url(url):
     fragment = None
     query = None
 
+    # workaround for ignoring <a href="tel:+17035713343"/>
+    if 'tel:' in url:
+        return Url(scheme, auth, host, port, path, query, fragment)
+
     # Scheme
     if '://' in url:
         scheme, url = url.split('://', 1)


### PR DESCRIPTION
Added condition to check if url contains tel: and ignoring it by returning empty url.
Not ideal solution, but works for me a quick and dirty fix to make copy work for sites containing new phone elements.