### PR TITLE
Fix missing links due to delayed parser events

### DIFF
--- a/pywebcopy/parsers.py
+++ b/pywebcopy/parsers.py
@@ -129,11 +129,13 @@ def iterparse(source, encoding=None, events=None,
 
         # parser could generate end events for html and
         # body tags which the parser itself inserted.
-        # for event, element in parser.read_events():
-        #     for child in links(element):
-        #         if child is None:
-        #             continue
-        #         yield child
+        # parser could often delay few events until closed
+        # https://bugs.launchpad.net/lxml/+bug/1990055
+        for event, element in parser.read_events():
+            for child in links(element):
+                if child is None:
+                    continue
+                yield child
 
         # it.root = root
         # noinspection PyUnusedLocal

--- a/pywebcopy/tests/test_iterparser.py
+++ b/pywebcopy/tests/test_iterparser.py
@@ -545,6 +545,13 @@ class TestFullHTMLParsing(unittest.TestCase):
         self.assertTrue(isinstance(self.context.root.getroottree(), lxml.etree._ElementTree))
 
 
+class TestFullHTMLParsingWithMultipleFeeds(TestFullHTMLParsing):
+    """Test multiple feed steps where feed ends within attribute value quotes"""
+
+    long_html = html.replace('<body>', f'<body><div class="{"a" * 0o3000}"></div>')
+    context = iterparse(BytesIO(long_html.encode('utf-8')))
+
+
 class TestFullLatin1EncodedHTMLParsing(unittest.TestCase):
 
     # Single instance of the parser to avoid creating anew each time.


### PR DESCRIPTION
Sometimes the HTMLPullParser does not dispatch all events until it is closed ([lxml bug report](https://bugs.launchpad.net/lxml/+bug/1990055)). As `pywebcopy` does not process those delayed events often few HTML links are not even crawled. This leads to missing resources while downloading webpages. For me no linked HTML pages were downloaded (#63).

This PR includes:
- Fix to this issue by processing those delayed events after parser is closed.
- Test cases to test the exact scenario.