### PR TITLE
lxml replaced by lxml-html-clean

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
 six
 requests
-lxml
+lxml-html-clean
 cachecontrol


### PR DESCRIPTION
@rajatomar788 `lxml` and `lxml-html-clean` are now separated. The project needs `lxml-html-clean`.